### PR TITLE
Add remote trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Alternatively you can visit the device detail page for any of your devices and u
 [remote control interface](https://info-beamer.com/blog/introducing-device-remote-control-interfaces) to trigger
 `Channel Up` or `Channel Down` events. This allows you to switch channels from remote.
 
+Additionally this package provides some API endpoints to switch channels. Those can be used by sending a message to the
+node to the following paths:
+
+| Path          | Data             |
+| ------------- | ---------------- |
+| channel/up    | empty            |
+| channel/down  | empty            |
+| channel/name  | channel name     |
+| channel/id    | channel index/id |
+
 ## Updates
 
 ### Version pi4

--- a/control.html
+++ b/control.html
@@ -13,12 +13,40 @@
       ib.setDefaultStyle();
 
       document.getElementById('up').addEventListener('click', function(evt) {
-        ib.sendCommand("remote/key", "channel-up");
+        ib.sendCommand("channel/up");
       });
 
       document.getElementById('down').addEventListener('click', function(evt) {
-        ib.sendCommand("remote/key", "channel-down");
+        ib.sendCommand("channel/down");
       });
+    </script>
+    <div id=channels-chooser></div>
+    <script>
+      ib.setDefaultStyle();
+      ib.ready.then(function() {
+        var container = document.getElementById('channels-chooser');
+        if (ib.config.channels.length == 0) {
+          var info = document.createElement("em");
+          info.appendChild(document.createTextNode("No channels configured for this setup."));
+          container.appendChild(info);
+          return;
+        }
+
+        for (var channel_id in ib.config.channels) {
+          var channel_name = ib.config.channels[channel_id].name;
+
+          var btn = document.createElement("button");
+          btn.appendChild(document.createTextNode(channel_name));
+          btn.classList.add('btn');
+          btn.classList.add('btn-default');
+          let payload =  (parseInt(channel_id)+1).toString();
+          btn.addEventListener('click', function(evt) {
+            ib.sendCommand("channel/id", payload);
+          });
+          container.appendChild(btn);
+          container.appendChild(document.createTextNode(" "));
+        }
+      })
     </script>
   </body>
 </html>

--- a/node.lua
+++ b/node.lua
@@ -63,25 +63,60 @@ local function send_channel()
     end
 end
 
+local function handle_channel_down()
+    channel = channel - 1
+    if channel < 1 then
+        channel = #channels
+    end
+    stop_and_wait(0)
+end
+
+local function handle_channel_up()
+    channel = channel + 1
+    if channel > #channels then
+        channel = 1
+    end
+    stop_and_wait(0)
+end
+
+local function handle_channel_name(name)
+    -- since name is not an unique identifier,
+    -- start at current channel position
+    -- and pick next name.
+    for i = 1, #channels do
+        -- start search at current position, wrap at list end
+        local idx = (channel + i - 1) % #channels + 1
+        if channels[idx].name == name then
+            channel = idx
+            break
+        end
+    end
+    stop_and_wait(0)
+end
+
+local function handle_channel_id(id)
+    local index = tonumber(id)
+    if index and 1 <= index and index <= #channels then
+        channel = index
+        stop_and_wait(0)
+    end
+end
+
 local function handle_key(key)
     if key == "channel-down" then
-        channel = channel - 1
-        if channel < 1 then
-            channel = #channels
-        end
-        stop_and_wait(0)
+        handle_channel_down()
     elseif key == "channel-up" then
-        channel = channel + 1
-        if channel > #channels then
-            channel = 1
-        end
-        stop_and_wait(0)
+        handle_channel_up()
     end
 end
 
 util.data_mapper{
     ["sys/cec/key"] = handle_key;
     ["remote"] = handle_key;
+    ["channel/up"] = handle_channel_up;
+    ["channel/down"] = handle_channel_down;
+    ["channel/name"] = handle_channel_name;
+    ["channel/id"] = handle_channel_id;
 }
 
 function node.render()

--- a/node.lua
+++ b/node.lua
@@ -102,7 +102,7 @@ local function handle_channel_id(id)
     end
 end
 
-local function handle_key(key)
+local function handle_cec(key)
     if key == "channel-down" then
         handle_channel_down()
     elseif key == "channel-up" then
@@ -111,8 +111,7 @@ local function handle_key(key)
 end
 
 util.data_mapper{
-    ["sys/cec/key"] = handle_key;
-    ["remote"] = handle_key;
+    ["sys/cec/key"] = handle_cec;
     ["channel/up"] = handle_channel_up;
     ["channel/down"] = handle_channel_down;
     ["channel/name"] = handle_channel_name;


### PR DESCRIPTION
This PR adds the possibility to directly choose channels either by name or by index of the channel in the list (starting at 1).

Since name is not an unique identifier there could be several streams with the same name.
To handle this case it acts as follow: When sending a name, the _next_ channel in the list (starting from the current playing one) with that name is chosen.

Remark: this PR changes(!) the current API endpoint for the current channel-up channel-down message endpoint from remote/[key] to channel/up channel/down.
Since this package is marked beta i took the liberty of just doing this breaking change, if you want to support both, just say and i will adapt the code.  

Fixes #1
e: tab-space mixup /o\ sorry, force pushed :)
